### PR TITLE
Replace Travis with Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,36 @@
+name: CI
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [12, 14, 16]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+          check-latest: true
+          cache: npm
+
+      - name: Cache Node modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: node_js
-node_js:
-  - 12

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 camelize-ts
 ===
-[![Build Status](https://travis-ci.com/kbrabrand/camelize-ts.svg?branch=master)](https://travis-ci.com/kbrabrand/camelize-ts)
+[![CI](https://github.com/kbrabrand/camelize-ts/actions/workflows/main.yml/badge.svg)](https://github.com/kbrabrand/camelize-ts/actions/workflows/main.yml)
 
 A typescript typed camelCase function that recursively camel cases a snake cased object structure. It camel cases a simple string too, if you need that.
 


### PR DESCRIPTION
This PR allows the CI to run on Github Actions instead of Travis. The added benefit of this is that forks can also run the CI without first having to set up Travis themselves.

This change also tests against all LTS versions of NodeJS (12, 14 and 16) instead of only version 12.