### PR TITLE
Add Dependabot to keep dependencies up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  open-pull-requests-limit: 999
+  rebase-strategy: disabled
+  schedule:
+    interval: weekly


### PR DESCRIPTION
Adds a [Dependabot ](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/enabling-and-disabling-dependabot-version-updates)configuration that can automatically keep the dependencies up to date.