### PR TITLE
Replace CommonJS distribution with ES modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "camelize-ts",
   "version": "1.0.8",
   "description": "Recursive camel casing of object property names with proper typing",
-  "main": "dist/index.js",
+  "type": "module",
+  "exports": "./dist/index.js",
+  "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+  },
   "scripts": {
     "test": "jest",
     "test:coverage": "jest --coverage",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,8 @@
   "compilerOptions": {
     "declaration": true,
     "experimentalDecorators": true,
-    "module": "commonjs",
-    "target": "es6",
-    "lib": ["es6", "esnext", "es2015"],
+    "module": "ES2020",
+    "target": "ES2020",
     "noImplicitAny": false,
     "suppressImplicitAnyIndexErrors": true,
     "moduleResolution": "node",


### PR DESCRIPTION
Converts the distribution to a full ESM package, following the recommendations of this [post](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c). Note that this removes the CommonJS distribution which is [intentional](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c#gistcomment-3850849), but a breaking change nonetheless.