### PR TITLE
Use es2019 target for node 12-16 support?

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "declaration": true,
     "experimentalDecorators": true,
     "module": "ES2020",
-    "target": "ES2020",
+    "target": "ES2019",
     "noImplicitAny": false,
     "suppressImplicitAnyIndexErrors": true,
     "moduleResolution": "node",


### PR DESCRIPTION
During CI on node 12 I got the following complaint:

> There is a mismatch between your NodeJs version v12.22.9 and your TypeScript target es2020. This might lead to some unexpected errors when running tests with `ts-jest`. To fix this, you can check https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping

This PR adjusts the target from `ES2020` 👉 `ES2019`. I've tested it in a project and is seems to work fine, but since you were the one that proposed the changes for the move from cjs to esm, would you mind having a look, @jonkoops?