### PR TITLE
Restore 'main' field in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.3",
   "description": "Recursive camel casing of object property names with proper typing",
   "type": "module",
+  "main": "./dist/index.js",
   "exports": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "engines": {


### PR DESCRIPTION
Restores the 'main' field in the package file to support older tooling (such as older versions of TypeScript).