### PR TITLE
Replace .npmignore with 'files' field

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,0 @@
-node_modules

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "files": ["dist"],
   "engines": {
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },


### PR DESCRIPTION
Replaces the .npmignore configuration with the 'files' field. This prevents some files (such as the `.github` directory) from being added to the package by accident.