### PR TITLE
Add pre-publish step to build code

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch --verbose",
-    "build": "tsc"
+    "build": "tsc",
+    "prepublishOnly": "npm run build"
   },
   "repository": "kbrabrand/camelize-ts",
   "author": {


### PR DESCRIPTION
Adds a 'prepublishOnly' task that runs the build before the package is published using `npm publish`. This mitigates the risk of accidentally forgetting to run the build before publishing.