### PR TITLE
Don't lowecase in typings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+coverage

--- a/__test/index.test.ts
+++ b/__test/index.test.ts
@@ -74,4 +74,31 @@ describe('camelize', () => {
 
     expect(camelized.aKey.aList[0].aDeeplyNestedObject.aDeeplyNestedObject.aDeeeeeplyNestedValue).toEqual('foo')
   })
+
+  it('leaves cased letters in place', () => {
+    type Snake = {
+      foo_bar_nested: {
+        Uppercased: {
+          foo_CAPS_foo: true
+        }
+      }
+      fooBar_bar: {
+        camelCased_foo_foo: 123
+      }
+    }
+
+    const a = camelize<Snake>({
+      foo_bar_nested: {
+        Uppercased: {
+          foo_CAPS_foo: true
+        }
+      },
+      fooBar_bar: {
+        camelCased_foo_foo: 123
+      }
+    })
+
+    expect(a.fooBarNested.Uppercased.fooCAPSFoo).toBe(true)
+    expect(a.fooBarBar.camelCasedFooFoo).toBe(123)
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
 type CamelCase<S extends string> =
   S extends `${infer P1}_${infer P2}${infer P3}`
-    ? `${Lowercase<P1>}${Uppercase<P2>}${CamelCase<P3>}`
-    : Lowercase<S>;
+    ? `${P1}${Uppercase<P2>}${CamelCase<P3>}`
+    : S;
+
+
 
 export type Camelize<T> = {
   [K in keyof T as CamelCase<string & K>]: T[K] extends Array<infer U>


### PR DESCRIPTION
The current behavior of the CamelCase type follows this logic:

1. Check if the string has two portions separated by an underscore
2. If separated by underscore: lowercase everything before the underscore, remove the underscore, uppercase the first letter after the underscore and CamelCase whatever comes after the letter that is uppercased.
3. If not separated by an underscore: lowercase everything

That means object types were transformed like this:

```ts
{
  foo_bar: {
    foo_camelCase_bar: number
  }
}

👇 

{
  fooBar: {
    fooCamelcaseBar: number
  }
}
```

...while in fact the actual camel casing function did not touch anything except the first letter after the underscore.

With this PR the typing is adjusted to match the actual behavior of the camelCase function. Now leaves casing as-is, except for uppercasing the first letter after an underscore.