### PR TITLE
make VSCode hover tooltip show computed human-readable type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ type CamelCase<S extends string> =
 
 
 
-export type Camelize<T> = {
+export type Camelize<T> = {} & {
   [K in keyof T as CamelCase<string & K>]: T[K] extends Array<infer U>
     ? U extends {}
       ? Array<Camelize<U>>


### PR DESCRIPTION
This makes the vscode hover tooltip show the computed new type instead of just Camelize<T>.

```
const a = {
    test_key: 'value',
}
const b = camelize(a)
/**
 * Before:
 * const b: Camelize<{
 *   test_key: {
 *     test_key: string;
 *   };
 * }>
 *
 * After:
 * const b: {
 *   testKey: {
 *     testKey: string;
 *   };
 * }
 */
```