### PR TITLE
Fix typing for camelizing arrays

### DIFF
--- a/__test/index.test.ts
+++ b/__test/index.test.ts
@@ -126,6 +126,10 @@ describe('camelize', () => {
 
       expect(t.oneB?.two_b?.three_a).toBe("c")
     })
+
+    it('camelizes arrays', () => {
+      expect(camelize([{foo_bar:{bar_foo:123}}], true)[0].fooBar.bar_foo).toBe(123)
+    })
   })
 
   describe('deep', () => {
@@ -250,6 +254,10 @@ describe('camelize', () => {
       };
 
       expect(t.oneB?.twoB?.threeA).toBe("c")
+    })
+
+    it('camelizes arrays', () => {
+      expect(camelize([{foo_bar:{bar_foo:123}}])[0].fooBar.barFoo).toBe(123)
     })
   })
 })


### PR DESCRIPTION
Based on the fix proposed in #47 by @LordZardeck. In addition to the array type inference fix a minor change has been done in the `walk` function to make that when doing a shallow walk of an array we camelize the first level in the array.