### PR TITLE
Improving the return type for a string argument

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,6 @@ export default function camelize<T, S extends boolean = false>(
    * If true, only the top level keys of the obj will be camel cased
    */
   shallow?: S
-): T extends String ? CamelCase<T> : Camelize<T, S> {
+): T extends string ? CamelCase<T> : Camelize<T, S> {
   return typeof obj === "string" ? camelCase(obj) : walk(obj, shallow);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,6 @@ export default function camelize<T, S extends boolean = false>(
    * If true, only the top level keys of the obj will be camel cased
    */
   shallow?: S
-): T extends String ? string : Camelize<T, S> {
+): T extends String ? CamelCase<T> : Camelize<T, S> {
   return typeof obj === "string" ? camelCase(obj) : walk(obj, shallow);
 }


### PR DESCRIPTION
Suggesting to improve the return type in case of a string argument.
Not just `string`, but a literal.

it works

![image](https://github.com/kbrabrand/camelize-ts/assets/13189514/f2b5b248-dcfc-493a-bd68-97135c81d595)
